### PR TITLE
Fix the logic for reloading streams

### DIFF
--- a/src/content/channels.ts
+++ b/src/content/channels.ts
@@ -53,6 +53,12 @@ export function addStream(channelId: string, streamData: IStream) {
 // Called to map the channels into their individual categories. This should run after all streams have been added.
 // This happens later in the process so that we can take out any channels that don't have streams available.
 export function mapChannelsIntoCategories() {
+    // Start by clearing out every list, if channels are already assigned
+    for (var category in channels) {
+        channels[category] = [ ];
+    }
+
+    // Assign channels to the categories if they have >= 1 stream available
     for (var channelId in channelsById) {
         var channel = channelsById[channelId];
         if (channel.streams.length === 0) {
@@ -71,13 +77,8 @@ export function mapChannelsIntoCategories() {
     }
 }
 
-// Reloads available channels. This will clear out the channels lists and reset all streams.
-export function resetChannels() {
-    // empty all channels
-    for (var category in channels) {
-        channels[category] = [ ];
-    }
-
+// Reloads available streams. This will set channels to have no streams available for them.
+export function resetStreams() {
     // set all sources to nothing
     for (var id in channelsById) {
         channelsById[id].streams = [];

--- a/src/content/sources.ts
+++ b/src/content/sources.ts
@@ -44,8 +44,11 @@ export async function initContent() {
 // Reloads streams, so that we can update what channels are available.
 export async function reloadStreams() {
     // reset all channel streams
-    channels.resetChannels();
+    channels.resetStreams();
 
     // refetch streams
     await fetchStreams();
+    
+    // re-map the streams into their categories
+    channels.mapChannelsIntoCategories();
 }


### PR DESCRIPTION
New logic is:
1. Empty streams for all channels
2. Fetch an updated list of streams and assign them to their channels
3. Empty channels for all categories
4. Re-assign channels to their categories if they have a stream available